### PR TITLE
Fix missing collection ids

### DIFF
--- a/datasets/spacenet_1.yaml
+++ b/datasets/spacenet_1.yaml
@@ -12,26 +12,10 @@ Tags:
 Citation: "SpaceNet on Amazon Web Services (AWS). “Datasets.” The SpaceNet Catalog.  Last modified April 30, 2018. Accessed on [Insert Date]. https://spacenetchallenge.github.io/datasets/datasetHomePage.html."
 Resources:
   - Description: SpaceNet 1 Rio Chipped Training Dataset
-    CollectionID: sn1_AOI_1_Rio
+    CollectionID: sn1_AOI_1_RIO
     Type: Labels, Source Imagery
     License: "[CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/)"
     DownloadSize: "3.3 GB"
-  - Description: SpaceNet 1 Vegas Chipped Training Dataset
-    CollectionID: sn1_AOI_2_Vegas
-    Type: Labels, Source Imagery
-    License: "[CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/)"
-  - Description: SpaceNet 1 Paris Chipped Training Dataset
-    CollectionID: sn1_AOI_3_Paris
-    Type: Labels, Source Imagery
-    License: "[CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/)"
-  - Description: SpaceNet 1 Shanghai Chipped Training Dataset
-    CollectionID: sn1_AOI_4_Shanghai
-    Type: Labels, Source Imagery
-    License: "[CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/)"
-  - Description: SpaceNet 1 Khartoum Chipped Training Dataset
-    CollectionID: sn1_AOI_5_Khartoum
-    Type: Labels, Source Imagery
-    License: "[CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/)"
 DataAtWork:
   Publications:
     - Title: "Getting Started With SpaceNet Data"

--- a/datasets/spacenet_6.yaml
+++ b/datasets/spacenet_6.yaml
@@ -16,7 +16,7 @@ Tags:
 Citation: "SpaceNet on Amazon Web Services (AWS). “Datasets.” The SpaceNet Catalog.  Last modified April 30, 2018. Accessed on [Insert Date]. https://spacenetchallenge.github.io/datasets/datasetHomePage.html."
 Resources:
   - Description: SpaceNet 6 Rotterdam Chipped Training Dataset
-    CollectionID: sn6_AOI_11_Rotterdaam
+    CollectionID: sn6_AOI_11_Rotterdam
     Type: Labels, Source Imagery
     License: "[CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/)"
 DataAtWork:


### PR DESCRIPTION
By iterating through all the datasets+collections, I noticed a few that are not present in the mlhub stac api (confirmed with Python client, and browsing https://api.radiant.earth/mlhub/v1/collections)

* sn1_AOI_1_RIO -> fixed case
* sn1_AOI_2_Vegas -> missing
* sn1_AOI_3_Paris -> missing
* sn1_AOI_4_Shanghai -> missing
* sn1_AOI_5_Khartoum -> missing
* sn6_AOI_11_Rotterdam -> fixed spelling

For the missing ones, actually I am not sure if that is a problem with the data registry, or with the stac api?


