### PR TITLE
Convert CreatedBy and Contact lists to strings

### DIFF
--- a/datasets/idiv_asia_crop_types.yaml
+++ b/datasets/idiv_asia_crop_types.yaml
@@ -2,9 +2,9 @@ Name: "A crop type dataset for consistent land cover classification in Central A
 Description: "Land cover is a key variable in the context of climate change. In particular, crop type information is essential to understand the spatial distribution of water usage and anticipate the risk of water scarcity and the consequent danger of food insecurity. This applies to arid regions such as the Aral Sea Basin (ASB), Central Asia, where agriculture relies heavily on irrigation. Here, remote sensing is valuable to map crop types, but its quality depends on consistent ground-truth data. Yet, in the ASB, such data is missing. Addressing this issue, we collected thousands of polygons on crop types, 97.7% of which in Uzbekistan and the remaining in Tajikistan. We collected 8,196 samples between 2015 and 2018, 213 in 2011 and 26 in 2008. Our data compiles samples for 40 crop types and is dominated by “cotton” (40%) and “wheat”, (25%). These data were meticulously validated using expert knowledge and remote sensing data and relied on transferable, open-source workflows that will assure the consistency of future sampling campaigns."
 Documentation: https://radiant-mlhub.s3-us-west-2.amazonaws.com/idiv-asia-crop-type/documentation.pdf
 Contact: christopher.conrad@geo.uni-halle.de
-CreatedBy:
-  - "[Institute of Geosciences and Geography](https://www.geo.uni-halle.de/)"
-  - "[German Centre for Integrative Biodiversity Research](https://www.idiv.de/en/groups_and_people/core_groups/macroecosocial.html)"
+CreatedBy: |
+  - [Institute of Geosciences and Geography](https://www.geo.uni-halle.de/)
+  - [German Centre for Integrative Biodiversity Research](https://www.idiv.de/en/groups_and_people/core_groups/macroecosocial.html)
 Tags:
   - crop type
   - agriculture

--- a/datasets/idiv_asia_crop_types.yaml
+++ b/datasets/idiv_asia_crop_types.yaml
@@ -2,9 +2,7 @@ Name: "A crop type dataset for consistent land cover classification in Central A
 Description: "Land cover is a key variable in the context of climate change. In particular, crop type information is essential to understand the spatial distribution of water usage and anticipate the risk of water scarcity and the consequent danger of food insecurity. This applies to arid regions such as the Aral Sea Basin (ASB), Central Asia, where agriculture relies heavily on irrigation. Here, remote sensing is valuable to map crop types, but its quality depends on consistent ground-truth data. Yet, in the ASB, such data is missing. Addressing this issue, we collected thousands of polygons on crop types, 97.7% of which in Uzbekistan and the remaining in Tajikistan. We collected 8,196 samples between 2015 and 2018, 213 in 2011 and 26 in 2008. Our data compiles samples for 40 crop types and is dominated by “cotton” (40%) and “wheat”, (25%). These data were meticulously validated using expert knowledge and remote sensing data and relied on transferable, open-source workflows that will assure the consistency of future sampling campaigns."
 Documentation: https://radiant-mlhub.s3-us-west-2.amazonaws.com/idiv-asia-crop-type/documentation.pdf
 Contact: christopher.conrad@geo.uni-halle.de
-CreatedBy: |
-  - [Institute of Geosciences and Geography](https://www.geo.uni-halle.de/)
-  - [German Centre for Integrative Biodiversity Research](https://www.idiv.de/en/groups_and_people/core_groups/macroecosocial.html)
+CreatedBy: "[Institute of Geosciences and Geography](https://www.geo.uni-halle.de/), [German Centre for Integrative Biodiversity Research](https://www.idiv.de/en/groups_and_people/core_groups/macroecosocial.html)"
 Tags:
   - crop type
   - agriculture

--- a/datasets/sen12floods.yaml
+++ b/datasets/sen12floods.yaml
@@ -1,7 +1,7 @@
 Name: "SEN12-FLOOD : A SAR and Multispectral Dataset for Flood Detection"
 Description: "These last decades, Earth Observation brought quantities of new perspectives from geosciences to human activity monitoring. As more data became available, artificial intelligence techniques led to very successful results for understanding remote sensing data. Moreover, various acquisition techniques such as Synthetic Aperture Radar (SAR) can also be used for problems that could not be tackled only through optical images. This is the case for weather-related disasters such as floods or hurricanes, which are generally associated with large clouds cover. Yet, machine learning on SAR data is still considered challenging due to the lack of available labeled data. This dataset is composed of co-registered optical and SAR images time series for the detection of flood events."
 Documentation: https://radiant-mlhub.s3-us-west-2.amazonaws.com/sen12floods/documentation.pdf
-Contact: 
+Contact: |
   - Bertrand.Le.Saux@esa.int
   - clement.rambour@cnam.fr 
 CreatedBy: "[CNAM](https://www.cnam.eu/site-en/ )"

--- a/datasets/sen12floods.yaml
+++ b/datasets/sen12floods.yaml
@@ -1,9 +1,7 @@
 Name: "SEN12-FLOOD : A SAR and Multispectral Dataset for Flood Detection"
 Description: "These last decades, Earth Observation brought quantities of new perspectives from geosciences to human activity monitoring. As more data became available, artificial intelligence techniques led to very successful results for understanding remote sensing data. Moreover, various acquisition techniques such as Synthetic Aperture Radar (SAR) can also be used for problems that could not be tackled only through optical images. This is the case for weather-related disasters such as floods or hurricanes, which are generally associated with large clouds cover. Yet, machine learning on SAR data is still considered challenging due to the lack of available labeled data. This dataset is composed of co-registered optical and SAR images time series for the detection of flood events."
 Documentation: https://radiant-mlhub.s3-us-west-2.amazonaws.com/sen12floods/documentation.pdf
-Contact: |
-  - Bertrand.Le.Saux@esa.int
-  - clement.rambour@cnam.fr 
+Contact: Bertrand.Le.Saux@esa.int, clement.rambour@cnam.fr 
 CreatedBy: "[CNAM](https://www.cnam.eu/site-en/ )"
 Tags:
   - sentinel-1


### PR DESCRIPTION
Changes the `Contact` field in `sen12floods.yaml` and the `CreatedBy` field in `idiv_asia_crop_types.yaml` to strings. These should show up as Markdown lists when rendered.

Fixes [ME-573](https://radiantearth.atlassian.net/browse/ME-573?atlOrigin=eyJpIjoiMDkzODllYTE0ZGVhNDliMmFkMTllYTM0ZmE2ODU0NDIiLCJwIjoiaiJ9)